### PR TITLE
Fix bug [undefined method] when application has no rating 

### DIFF
--- a/lib/google_play_search/app_parser.rb
+++ b/lib/google_play_search/app_parser.rb
@@ -69,7 +69,7 @@ module GooglePlaySearch
 
     def get_app_rating(app_content)
       ratings = app_content.css("div.current-rating")
-      if ratings
+      if ratings && ratings.first
         rating_str = ratings.first['style']
         unless rating_str.empty?
           return rating_str[/\d+\.?\d?/].to_f / 100 * 5


### PR DESCRIPTION
Hi @grantchen , I found bellow situation.

# Problem
When we search for apps that have no rating, so in `get_app_rating` method, error will occurs.

```ruby
/google_play_search/app_parser.rb:73:in `get_app_rating': undefined method `[]' for nil:NilClass (NoMethodError)
```

# Example
## Has rating

![good-case](https://cloud.githubusercontent.com/assets/1573290/7224272/cd22b7f2-e76a-11e4-90d1-996356c945d8.png)

## Has no rating
There is no DOM, `div.current-rating`.

![bad-case](https://cloud.githubusercontent.com/assets/1573290/7224297/46b4536e-e76b-11e4-8fa4-57f6288c7ff9.png)

One more thing, i've changed the original logic, to return nil if the app has no rating.
