### PR TITLE
Fix for case where there are no search results

### DIFF
--- a/lib/google_play_search/search.rb
+++ b/lib/google_play_search/search.rb
@@ -56,7 +56,9 @@ module GooglePlaySearch
     end
 
     def get_next_page_token(response_body)
-      @next_page_token = response_body.match(/(GAEi+.+:S:.{11})\\42/)[1][-22..-1]
+      if response_body.match(/(GAEi+.+:S:.{11})\\42/)
+        @next_page_token = $~[1][-22..-1]
+      end
     end
   end
 end

--- a/test/google_play_search_test.rb
+++ b/test/google_play_search_test.rb
@@ -18,6 +18,13 @@ describe GooglePlaySearch do
       assert_equal @gps.current_page, 2
     end
 
+    it "should return no apps when there are no results" do
+      apps = @gps.search('qqqqqqqqqqqqqqqqqqqq')
+      assert_instance_of Array, apps
+      assert_empty apps
+      assert_equal @gps.current_page, 1
+    end
+
     it "rating should work" do
       @gps = GooglePlaySearch::Search.new({rating: "1"})
       apps = @gps.search("bird")


### PR DESCRIPTION
In the case that there are no results there is not a next page token
and so previous to this change the get_next_page_token
method would result in the exception "undefined method `[]' for
nil:NilClass"