### PR TITLE
Fix GooglePlaySearch::App#get_long_description

### DIFF
--- a/lib/google_play_search/app.rb
+++ b/lib/google_play_search/app.rb
@@ -98,7 +98,7 @@ module GooglePlaySearch
     end
 
     def get_long_description(google_play_html)
-      long_description = google_play_html.search("div[class='id-app-orig-desc']").first
+      long_description = google_play_html.search("div[itemprop='description']").first
       long_description.content.strip if long_description
     end
 


### PR DESCRIPTION
Hi @grantchen, I fixed `get_long_description`.

# Problem
cannot get app long description. (maybe html tag changed.)

# ScreenShot
current html tag. ↓
![_2017-07-06_00_00_02](https://user-images.githubusercontent.com/1281509/27870649-6200fd76-61de-11e7-81e0-59a2b0b94dd2.png)
